### PR TITLE
docs: expand english readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,60 @@
-Prerequisites
-Before setting up and running the Predictive Maintenance System, ensure that your system meets the following prerequisites:
+# Real-Time Predictive Maintenance Platform
 
-Operating System:
+## Overview
+This project delivers an end-to-end, production-ready predictive maintenance system that turns raw sensor streams into actionable maintenance work orders. It combines deep learning, streaming analytics, and intuitive dashboards to minimize downtime, extend asset life, and maximize business value.
 
-Windows
-Python:
+## Architecture at a Glance
+- **src/** – core logic including synthetic data generation, model training scripts, statistical validation utilities, and shared logging helpers.
+- **RealTimeProcessing/** – real-time pipeline that consumes Kafka messages, extracts features on the fly, performs model inference, and persists results.
+- **IntegrationWithExistingSystems/** – adapters that interface with [openMAINT](https://www.openmaint.org/) to create work orders and to ingest asset metadata.
+- **dashboards/** – configurations for Grafana and a Dash dashboard to visualize predictions, trends, and key metrics.
+- **models/** – trained CNN, LSTM, hybrid CNN‑LSTM models, and supervised anomaly detection ensembles.
+- **tests/** – unit and integration tests covering Kafka flows, database interactions, and the openMAINT bridge.
+- **docker-compose.yml** – spins up Zookeeper and Kafka so the complete streaming stack can run locally with a single command.
 
-Python 3.10.0 is required. You can download it from the official Python website. https://www.python.org/downloads/.
-Docker:
+## Data & Modeling Strategy
+### Synthetic Data Creation & Validation
+- A synthetic generator produces 10,000 samples that emulate real sensor behavior and embed four failure modes: **TWF**, **HDF**, **PWF**, and **OSF**.
+- Kolmogorov–Smirnov and Chi‑Square tests compare synthetic distributions with historical data to guarantee statistical fidelity.
 
-Docker is essential for managing containerized services like Kafka openmaint and PostgreSQL.
-Installation:
-Windows :
-Download and install Docker Desktop from the official Docker website https://www.docker.com/.
+### Model Training
+- **CNN / LSTM / CNN‑LSTM** networks trained with K‑fold cross‑validation, class balancing, early stopping, and automated hyper‑parameter tuning.
+- **Isolation Forest Ensemble** that combines DBSCAN, One‑Class SVM, Local Outlier Factor, and Random Forest; predictions are weighted by validation performance.
+- Detailed logs capture AUC, F1, and PR‑AUC for every fold, enabling transparent model governance.
 
-Post-Installation:
-Ensure Docker is running. You can verify by running:
+## Real-Time Data Pipeline
+1. **SensorDataSimulator** streams IoT measurements to Kafka topics.
+2. **RealTimeProcessor** loads all trained models, performs feature engineering and normalization, then scores each event in real time.
+3. Alerts are published to a dedicated topic where **openmaint_consumer** converts them into openMAINT work orders.
+4. Metrics flow to Grafana dashboards for interactive monitoring.
 
+## Containerised Infrastructure
+- `docker-compose.yml` provisions Zookeeper and Kafka, allowing the streaming backbone to be bootstrapped in seconds.
+- The same file can be extended to include PostgreSQL, Grafana, and openMAINT, ensuring a consistent and reproducible development environment.
 
-docker --version
+## Getting Started
+1. **Install Dependencies**
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # or venv\Scripts\activate on Windows
+   pip install -r predictive_maintenance/requirements.txt
+   ```
+2. **Launch Kafka Stack**
+   ```bash
+   cd predictive_maintenance
+   docker compose up -d
+   ```
+3. **Run the Full Pipeline**
+   ```bash
+   python run.py
+   ```
+   The script boots Kafka, simulates sensor data, performs inference, and interfaces with openMAINT and Grafana.
 
-You should see output similar to Docker version 20.10.7, build f0df350.
+## Achievements & Challenges
+- Engineered a statistically faithful synthetic data generator with complex failure logic.
+- Trained multiple model architectures with dynamic configuration to avoid overfitting.
+- Delivered a real-time, end-to-end pipeline—from simulation to automatic work order creation.
+- Authored automated tests for Kafka infrastructure and openMAINT integration.
 
-Docker Compose:
-Docker Compose typically comes bundled with Docker Desktop. Verify its installation:
-
-docker-compose --version
-Expected output: docker-compose version 1.29.2, build 5becea4c.
-
-
-
-Setup
-1. Clone the Repository
-
-Begin by cloning the repository to your local machine using Git.
-
-
-git clone https://github.com/neo050/-maintenance-system.git
-
-cd -maintenance-system
-
-2. Create a Virtual Environment
-It's recommended to use a virtual environment to manage your project's dependencies and avoid conflicts with other projects.
-
-
-python -m venv venv
-
-3. Activate the Virtual Environment
-
-Activate the virtual environment you just created.
-
-Windows
-
-venv\Scripts\activate
-
-After activation, your command prompt should reflect the active virtual environment, e.g., (venv) C:\path\to\project>.
-
-4. Install Dependencies
-
-Install the required Python packages using pip and the provided requirements.txt file.
-
-
-pip install -r requirements.txt
-
-Note: If you encounter any issues during installation, ensure that your pip is up to date:
-
-
-pip install --upgrade pip
-
-5. Run the Application
-
-Once all dependencies are installed, you can run the main application script.
-
-
-python run.py
-
-
+## Contributing
+This project is built for learning and demonstration. Contributions, feedback, and collaboration are welcome!


### PR DESCRIPTION
## Summary
- rewrite README in English with marketing tone
- document architecture, modeling strategy, real-time pipeline, and dockerized stack

## Testing
- `pytest predictive_maintenance/tests -q` *(fails: ModuleNotFoundError: No module named 'kafka', 'IntegrationWithExistingSystems', 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68976375872c832296f4d980984bb8e6